### PR TITLE
Add an option to save the output to a different folder from 'save_dir'.

### DIFF
--- a/neural_admixture/src/utils.py
+++ b/neural_admixture/src/utils.py
@@ -58,7 +58,11 @@ def parse_infer_args():
     parser.add_argument('--data_path', required=True, type=str, help='Path containing the main data')
     parser.add_argument('--name', required=True, type=str, help='Trained experiment/model name')
     parser.add_argument('--batch_size', required=False, default=400, type=int, help='Batch size')
-    return parser.parse_args()
+    parser.add_argumnet('--out_dir', required=False, type=str, help='Path to save the output. If not given sets to --save_dir.')
+    args = parser.parse_args()
+    if args.out_dir is None:
+        args.out_dir = args.save_dir
+    return args
 
 def initialize_wandb(run_name, trX, valX, args, out_path, silent=True):
     if run_name is None:

--- a/neural_admixture/src/utils.py
+++ b/neural_admixture/src/utils.py
@@ -58,7 +58,7 @@ def parse_infer_args():
     parser.add_argument('--data_path', required=True, type=str, help='Path containing the main data')
     parser.add_argument('--name', required=True, type=str, help='Trained experiment/model name')
     parser.add_argument('--batch_size', required=False, default=400, type=int, help='Batch size')
-    parser.add_argumnet('--out_dir', required=False, type=str, help='Path to save the output. If not given sets to --save_dir.')
+    parser.add_argument('--out_dir', required=False, type=str, help='Path to save the output. If not given sets to --save_dir.')
     args = parser.parse_args()
     if args.out_dir is None:
         args.out_dir = args.save_dir


### PR DESCRIPTION
Modified parse_infer_args to add the option '--out_dir' for the path to store the output, inference.py was modified accordingly to use this variable as output directory.
If '--out_dir' is not given this variable sets to '--save_dir' which is a required argument.