### PR TITLE
patching supervised loss weight because it is not passed to NeuralAdmixture class 

### DIFF
--- a/neural_admixture/model/train.py
+++ b/neural_admixture/model/train.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 def train(epochs: int, batch_size: int, learning_rate: float, K: int, seed: int,
         data: torch.Tensor, device: torch.device, num_gpus: int, hidden_size: int, 
-        master: bool, V: np.ndarray, pops : np.ndarray, min_k: int=None, max_k: int=None, n_components: int=None) -> Tuple[torch.Tensor, torch.Tensor, torch.nn.Module]:
+        master: bool, V: np.ndarray, pops : np.ndarray, min_k: int=None, max_k: int=None, n_components: int=None, supervised_loss_weight: int=100) -> Tuple[torch.Tensor, torch.Tensor, torch.nn.Module]:
         """
         Initializes P and Q matrices and trains a neural admixture model using GMM.
 
@@ -128,7 +128,7 @@ def train(epochs: int, batch_size: int, learning_rate: float, K: int, seed: int,
             pack2bit = None
             packed_data = data
         
-        model = NeuralAdmixture(K, epochs, batch_size, learning_rate, device, seed, num_gpus, master, pack2bit, min_k, max_k)
+        model = NeuralAdmixture(K, epochs, batch_size, learning_rate, device, seed, num_gpus, master, pack2bit, min_k, max_k,supervised_loss_weight)
         Qs, Ps, model = model.launch_training(P_init, packed_data, hidden_size, V.shape[1], V, M, N, pops)
         
         if master:

--- a/neural_admixture/src/main.py
+++ b/neural_admixture/src/main.py
@@ -32,8 +32,9 @@ def fit_model(args: argparse.Namespace, data: torch.Tensor, device: torch.device
         min_k = int(args.min_k)
         max_k = int(args.max_k)
         K = None
-
-    Ps, Qs, model = train(epochs, batch_size, learning_rate, K, seed, data, device, num_gpus, hidden_size, master, V, pops, min_k, max_k, n_components)
+    if args.supervised_loss_weight is None:
+        args.supervised_loss_weight = 100
+    Ps, Qs, model = train(epochs, batch_size, learning_rate, K, seed, data, device, num_gpus, hidden_size, master, V, pops, min_k, max_k, n_components, args.supervised_loss_weight)
     
     if master:
         Path(save_dir).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Hello again,

Thanks again for answering to my issue. 

I noticed that the `--supervised_loss_weight` parameter is available to modify the supervised loss weight. However, it doesn’t seem to propagate correctly into the `NeuralAdmixture` class, the code always uses the default value of 100.

I applied a small patch to fix this and confirmed that the parameter now behaves as expected on my dataset.

My commit is just a suggestion, please feel free to use or adapt it if you find it helpful.

# Examples

In my dataset, when I'm using the pip installed version of neural-admixture (1.6.7) :

```bash
for e in 100 200 500 1000 2000 5000 10000 20000 50000 100000; do
    neural-admixture train --k 11 --data_path ../results/20250801/genotypes/20250801_popref.bed --threads 20 --save_dir . --num_gpus 1 --name neural_20250801_svp_train_500_${e} --pops_path ../results/20250801/genotypes/20250801_popref.neuralpop --supervised_loss_weight ${e} --epochs 500
done
```

<img width="1060" height="749" alt="before_code_update_loss_weight" src="https://github.com/user-attachments/assets/3c39747b-143a-4946-8355-bba75b90da38" />

Each facet on the second plot I've show the Q matrix for the training dataset when varying the  `--supervised_loss_weight` parameter but as you can see nothing change. On the top plot you can see the result with classic Admixture as a comparison.

And with the patch I did: 

<img width="3072" height="3072" alt="after_code_update_loss_weight" src="https://github.com/user-attachments/assets/356f04a9-21c3-4b31-a3e4-1fdd83b27e13" />

Best regards,
Vincent Rocher
